### PR TITLE
bump xmlbf to >= 0.4, remove upper bounds on xmlbf and xmlbf-xeno

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -27,8 +27,8 @@ dependencies:
   - bytestring
   - http-media >= 0.7 && < 0.8
   - servant >= 0.11 && < 0.14
-  - xmlbf >= 0.3 && < 0.4
-  - xmlbf-xeno >= 0.1 && < 0.2
+  - xmlbf >= 0.4
+  - xmlbf-xeno >= 0.1
 
 library:
   source-dirs: src

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,5 +5,5 @@ packages:
 
 extra-deps:
   - html-entities-1.1.4.2
-  - xmlbf-0.3
+  - xmlbf-0.4
   - xmlbf-xeno-0.1.1


### PR DESCRIPTION
`xmlbf < 0.4` had problems parsing nested elements. It's been fixed now, so `>= 0.4` should be the encouraged version. 

As the author of `xmlbf`, I also recommend removing the upper bounds for `xmlbf` and `xmlbf-xeno`. I don't expect newer versions to ever break this library.